### PR TITLE
re-added endpoint parsing login (originally removed and replced with …

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,8 +151,10 @@ Usage of ./aws-es-proxy:
         Print user requests
   -version
         Print aws-es-proxy version
+  -assume
+        Optionally specify role to assume
   -region
-        AWS region (ex. us-west-2) (Required)
+        AWS Region, optional (ex. us-west-2)
   -insecure
         Will not verify SSL (default false)
 ```


### PR DESCRIPTION
…a `region` flag)

made `-region` flag optional, if not supplied will go through the endpoint parsing logic instead
edited `README.md` description for region flag
added "assume" description to `--help` in `README.md`